### PR TITLE
Use localhost rather than 127.0.0.1 so both 127.0.0.1 and ::1 work

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@
 class eximsimple::params {
     $smarthost = 'smtp.example.com/mx'
     $domain = 'example.com'
-    $local_interfaces = '127.0.0.1'
+    $local_interfaces = 'localhost'
     $root = 'root@example.com'
     $host_in_subject = false
 


### PR DESCRIPTION
Hi Dan,

This fixes a problem we had on w-py-p7 and p8 where Django can't connect to localhost port 25...

Thanks,

Jon.